### PR TITLE
Make menu icons accessible.

### DIFF
--- a/fontawesome_menu.module
+++ b/fontawesome_menu.module
@@ -120,7 +120,7 @@ function fontawesome_menu_menu_link($variables) {
 
   if (!empty($variables['element']['#original_link']['fa_icon'])) {
     $icon = $variables['element']['#original_link']['fa_icon'];
-    $icon_markup = '<i class="fa ' . $icon . '"></i>';
+    $icon_markup = '<i aria-hidden class="fa ' . $icon . '"></i>';
     $title = $icon_markup . ' <span class="menu-link-title">' . $element['#title'] . '</span>';
     $element['#localized_options']['html'] = TRUE;
   }


### PR DESCRIPTION
Since menu icons are intended to add value to a menu link, we should mark the FontAwesome icon as aria-hidden so screen readers don't try and read it.